### PR TITLE
Cambios en definicion diccionario y otros generales

### DIFF
--- a/_episodes/01-short-introduction-to-Python.md
+++ b/_episodes/01-short-introduction-to-Python.md
@@ -129,7 +129,7 @@ type(6.02)
 
 La variable `text` es de tipo 'str', abreviatura de **string** o cadena de caracteres. Las cadenas almacenan
 secuencias de caracteres, que pueden ser letras, números, puntuación
-o más formas exóticas de texto (¡incluso emoji!).
+o formas más exóticas de texto (¡incluso emoji!).
 
 También podemos ver el valor de algo usando otra función incorporada, `print`:
 
@@ -180,7 +180,7 @@ Data Carpentry
 
 Nota que "Data Carpentry" se imprime una vez.
 
-**Sugerencia**: `print` y `type` son funciones incorporadas en Python. Mas adelante en esta
+**Sugerencia**: `print` y `type` son funciones incorporadas en Python. Más adelante en esta
 lección, veremos métodos y funciones definidas por el usuario. La documentación 
 de Python es excelente para darte una referencia sobre las diferencias entre ellos.
 
@@ -226,7 +226,7 @@ Podemos realizar cálculos matemáticos en Python usando los operadores básicos
 {: .output}
 
 
-También podemos utilizar operadores de comparación y lógica:
+También podemos utilizar operadores de comparación y lógicos:
 `<,>, ==,! =, <=,> =` y declaraciones de identidad como
 `and, or, not`. El tipo de datos devuelto por estos operadres es
 llamado _**boolean**_ y retorna verdadero o falso, como ves a continuación.

--- a/_episodes/01-short-introduction-to-Python.md
+++ b/_episodes/01-short-introduction-to-Python.md
@@ -365,7 +365,7 @@ a_list = [1, 2, 3]
 
 ## Diccionarios
 
-Un diccionario **dictionary** es un contenedor que almacena pares de objetos - llaves y valores.
+Un diccionario **dictionary** es un contenedor que almacena pares de objetos - claves y valores.
 
 ~~~
 translation = {'one': 1, 'two': 2}
@@ -377,9 +377,9 @@ translation['one']
 ~~~
 {: .output}
 
-Los diccionarios funcionan como listas, excepto que se crea el índice utilizando *llaves*  **keys**.
-Puedes pensar en una llave como nombre o un identificador único para un conjunto de valores
-en el diccionario. Las llaves solo pueden tener tipos particulares, tienen que ser
+Los diccionarios funcionan como listas, excepto que se crea el índice utilizando *claves*  **keys**.
+Puedes pensar en una clave como un nombre o un identificador único para un conjunto de valores
+en el diccionario. Las claves sólo pueden tener tipos particulares, tienen que ser
 "**hashable**". Las cadenas y los tipos numéricos son aceptables, pero las listas no lo son.
 
 ~~~
@@ -406,7 +406,7 @@ TypeError: unhashable type: 'list'
 En Python, un "**Traceback**" es un bloque de error de varias líneas impreso para el
 usuario.
 
-Para agregar un elemento al diccionario, asignamos un valor a una nueva llave:
+Para agregar un elemento al diccionario, asignamos un valor a una nueva clave:
 
 ~~~
 rev = {1: 'one', 2: 'two'}
@@ -452,7 +452,7 @@ for key in rev.keys():
 > ## Cambiando diccionarios
 >
 > 1. Primero, imprime el valor de `rev` del diccionario en la pantalla.
-> 2. Reasigna el segundo valor (parar el *par llave: valor*) para que ya no
+> 2. Reasigna el segundo valor (parar el *par clave: valor*) para que ya no
 > lea "dos" sino "manzana".
 > 3. Imprime el valor de `rev` en la pantalla nuevamente y ve si el valor ha cambiado.
 >
@@ -460,7 +460,7 @@ for key in rev.keys():
 
 
 Es importante tener en cuenta que los diccionarios están "desordenados" y no recuerdan
-la secuencia de sus elementos (es decir, el orden en el que los pares llave: valor fueron
+la secuencia de sus elementos (es decir, el orden en el que los pares clave: valor fueron
 añadidos al diccionario). Debido a esto, el orden en que los elementos son
 devuelto en los bucles sobre los diccionarios, puede aparecer al azar e incluso puede cambiar
 con el tiempo.


### PR DESCRIPTION


El cambio en diccionarios es importante porque se definen los pares como "clave:valor" en vez de "llave:valor" ya que en computación se utiliza clave como traducción de *key*  para indexar.  Además, si bien la traducción de key puede ser llave, como al definir un diccionario se encierra entre los signos { } que se llaman llaves, puede dar lugar a confusión.  Se adjuntan evidencias en la web de este uso:
 https://librosweb.es/libro/algoritmos_python/capitulo_9/utilizando_diccionarios_en_python.html
donde dice: “De la misma forma que con listas, es posible definir un diccionario directamente con los miembros que va a contener, o bien inicializar el diccionario vacío y luego agregar los valores de a uno o de a muchos. Para definirlo junto con los miembros que va a contener, se encierra el listado de valores entre llaves, las parejas de clave y valor se separan con comas, y la clave y el valor se separan con :”.
punto = {'x': 2, 'y': 1, 'z': 4}

Y también:
http://docs.python.org.ar/tutorial/3/datastructures.html
Que dice: “Lo mejor es pensar en un diccionario como un conjunto no ordenado de pares clave: valor, con el requerimiento de que las claves sean únicas (dentro de un diccionario en particular). Un par de llaves crean un diccionario vacío: {}. Colocar una lista de pares clave:valor separados por comas entre las llaves añade pares clave:valor iniciales al diccionario; esta también es la forma en que los diccionarios se presentan en la salida.”